### PR TITLE
EXAMINE verb; changes to Containers

### DIFF
--- a/_devw/dw2/main.json
+++ b/_devw/dw2/main.json
@@ -41,7 +41,7 @@
 
 ["rem", "r3 West Shelter"]
 ["itemc",   "r3-t1", "a black plastic garbage bag", "", false, 0.1, 1, false, true,
-          { "i": [30, 55] } ]
+          { "i": [30, 55], "u": ["x", 100] } ]
 ["itemc",   "r3-t2", "a metal first-aid chest", "", false, "x", "x", true, false,
           { "i": [1000, 1000], "b": ["x", 200] } ]
 ["item",    "r3-t2-t1", "some clean white gauze", "", false, 0.05, 0.2 ]
@@ -50,10 +50,12 @@
 ["item",    "r3-t3", "a small metal key", "", false, 0.01, 0.005 ]
 ["itemc",   "r3-t4", "some rough wooden picnic tables", "", true, "x", "x", false, false,
           { "o": [1000, 3000], "u": ["x", 3000] } ]
+["itemc",   "r3-t5", "a tattered cardboard box", "", false, 0.5, 200, false, true,
+          { "i": [20, 200], "b": ["x", 100], "u": ["x", 200] } ]
 
 ["pop", "r3-t2", "i", "r3-t2-t1", "r3-t2-t2", "r3-t2-t3" ]
 ["pop", "r3", "s", "r3-t4" ]
-["pop", "r3", "c", "r3-t1", "r3-t2", "r3-t3" ]
+["pop", "r3", "c", "r3-t1", "r3-t2", "r3-t3", "r3-t5" ]
 
 
 ["rem", "r4 Branbury Beach Green, West"]
@@ -98,10 +100,13 @@
 ["rem", "r9 Branbury State Park, Parking Lot"]
 
 ["rem", "r10", "Underground Chamber"]
-["dwy",  "r10-t1", "an/a iron-rimmed hole", "in the ceiling of the chamber", false, "x", "x", true ]
-["item", "r10-t2", "some rusty iron gratings", "", true, "x", "x" ]
+["dwy",   "r10-t1", "an/a iron-rimmed hole", "in the ceiling of the chamber", false, "x", "x", true ]
+["item",  "r10-t2", "some rusty iron gratings", "", true, "x", "x" ]
+["cloth", "r10-t3", "an/a iron band", "with a wavy pattern engraved on it", false,
+          0.010, 0.010, "misc"]
 
 ["pop", "r10", "s", "r10-t1", "r10-t2" ]
+["pop", "r10", "c", "r10-t3" ]
 
 
 ["rem", "Miscellaneous stuff"]

--- a/_devw/dw2/pc_dir/ethan.json
+++ b/_devw/dw2/pc_dir/ethan.json
@@ -1,1 +1,1 @@
-{"RefToken":"pc2","PassHash":"$2a$04$EK19DjFon0dNwlbKmN2V2.XqZKPeW43HfWTX4PugjW2zUXGMYPliq","NameTitle":"","NameFirst":"Ethan","NameRest":"","RightHand":"","LeftHand":"","Gender":2,"Location":"r4","Inventory":[]}
+{"RefToken":"pc2","PassHash":"$2a$04$EK19DjFon0dNwlbKmN2V2.XqZKPeW43HfWTX4PugjW2zUXGMYPliq","NameTitle":"","NameFirst":"Ethan","NameRest":"","RightHand":"","LeftHand":"","Gender":2,"Location":"r3","Inventory":[]}

--- a/_devw/dw2/pc_dir/weston.json
+++ b/_devw/dw2/pc_dir/weston.json
@@ -1,1 +1,1 @@
-{"RefToken":"pc1","PassHash":"$2a$04$YNUCazpTxUEAYc7JUwD5GeyAm7jc2zIsPdDRVOOuuneCD6E9I7Ou2","NameTitle":"","NameFirst":"Weston","NameRest":"","RightHand":"","LeftHand":"","Gender":2,"Location":"r4","Inventory":[]}
+{"RefToken":"pc1","PassHash":"$2a$04$YNUCazpTxUEAYc7JUwD5GeyAm7jc2zIsPdDRVOOuuneCD6E9I7Ou2","NameTitle":"","NameFirst":"Weston","NameRest":"","RightHand":"","LeftHand":"","Gender":2,"Location":"r3","Inventory":[]}

--- a/load/build/build.go
+++ b/load/build/build.go
@@ -75,8 +75,8 @@ func AddCannotGetMessage(data []interface{}) error {
   mesg   := data[1].(string)
   
   obj := ref.Deref(keyRef)
-  obj.SetData("cannot_get_message_script_message", mesg)
-  scripts.Bind(obj, "get", "cannot_get_message_script")
-  scripts.Bind(obj, "take", "cannot_get_message_script")
+  obj.SetData("CGMS_msg", mesg)
+  scripts.Bind(obj, "get", "CGMS")
+  scripts.Bind(obj, "take", "CGMS")
   return nil
 }

--- a/pc/examine.go
+++ b/pc/examine.go
@@ -1,0 +1,75 @@
+// examine.go
+//
+// dta5 PlayerChar verb for looking more closely at an object.
+//
+// updated 2017-08-15
+//
+package pc
+
+import(
+        "github.com/delicb/gstring";
+        "dta5/msg"; "dta5/name"; "dta5/room"; "dta5/thing"; "dta5/util";
+)
+
+func DoExamine(pp *PlayerChar, verb string, dobj thing.Thing,
+               prep string, iobj thing.Thing, text string) {
+  
+  if dobj == nil {
+    pp.QWrite("Examine what?")
+    return
+  }
+  
+  bod := pp.Body()
+  if !bod.IsHolding(dobj) {
+    pp.QWrite("You must be holding %s to examine it.", dobj.Normal(name.DEF_ART))
+    return
+  }
+  
+  m := msg.New("%s examines %s %s.", util.Cap(pp.Normal(0)),
+                pp.PossPronoun(), dobj.Normal(name.NO_ART))
+  m.Add(pp, "You examine your %s.", dobj.Normal(name.NO_ART))
+  pp.where.Place.(*room.Room).Deliver(m)
+  
+  pp.QWrite("You see %s.", dobj.Full(0))
+  pp.QWrite(dobj.Desc())
+  
+  if t, ok := dobj.(thing.Openable); ok {
+    if t.IsToggleable() {
+      if t.IsOpen() {
+        pp.QWrite("The %s is open.", dobj.Short(name.NO_ART))
+      } else {
+        pp.QWrite("The %s is closed.", dobj.Short(name.NO_ART))
+      }
+    }
+  }
+  
+  if t, ok := dobj.(thing.Container); ok {
+    store_preps := make([]string, 0, 4)
+    for _, s_num := range []byte{thing.IN, thing.ON, thing.BEHIND, thing.UNDER} {
+      if t.Side(s_num) != nil {
+        store_preps = append(store_preps, thing.SideStr(s_num))
+      }
+    }
+    if len(store_preps) > 0 {
+      pp.QWrite("It appears you can store things %s %s.",
+                util.EnglishList(store_preps), dobj.Short(name.DEF_ART))
+    }
+  }
+  
+  if t, ok := dobj.(thing.Wearable); ok {
+    slot := t.Slot()
+    num_slots, _ := bod.WornSlots(slot)
+    if num_slots > 0 {
+      worn_slot_str := bod.WornSlotName(slot)
+      if worn_slot_str == "" {
+        pp.QWrite("You appear to be able to wear %s.", dobj.Short(name.DEF_ART))
+      } else {
+        worn_slot := gstring.Sprintm(worn_slot_str, map[string]interface{} { "pp": "your" })
+        pp.QWrite("You appear to be able to wear %s %s.",
+                  dobj.Short(name.DEF_ART), worn_slot)
+      }
+    } else {
+      pp.QWrite("The %s appears wearable, but not by you.", dobj.Short(name.NO_ART))
+    }
+  }
+}

--- a/pc/parse.go
+++ b/pc/parse.go
@@ -11,8 +11,9 @@ import( "strings";
 )
 
 var parseVerbs []string = []string{
-  "close", "drop", "exits", "get", "go", "help", "inventory", "look", "lock",
-  "open", "put", "remove", "say", "swap", "take", "unlock", "wear",
+  "close", "drop", "examine", "exits", "get", "go", "help", "inventory", 
+  "look", "lock", "open", "put", "remove", "say", "swap", "take",
+  "unlock", "wear",
   
   // point/wave (pc/point.go)
   
@@ -46,6 +47,7 @@ type DoFunc func(*PlayerChar, string, thing.Thing, string, thing.Thing, string)
 var parseDispatch map[string]ParseFunc = map[string]ParseFunc {
   "close":      ParseLikeLook,
   "drop":       ParseLikePut,
+  "examine":    ParseLikePut,
   "exits":      ParseIntransitive,
   "get":        ParseLikeLook,
   "go":         ParseGo,
@@ -91,6 +93,7 @@ var parseDispatch map[string]ParseFunc = map[string]ParseFunc {
 var doDispatch map[string]DoFunc = map[string]DoFunc {
   "close":      DoClose,
   "drop":       DoPut,
+  "examine":    DoExamine,
   "exits":      DoExits,
   "get":        DoGet,
   "go":         DoMove,

--- a/pc/wear.go
+++ b/pc/wear.go
@@ -2,7 +2,7 @@
 //
 // dta5 PlayerChar wear/remove verbs
 //
-// updated 2017-08-11
+// updated 2017-08-15
 //
 package pc
 
@@ -58,7 +58,13 @@ func DoWear(pp *PlayerChar, verb string, dobj thing.Thing,
                                       "verb": "puts",
                                       "pp":   pp.PossPronoun(),
                                       "dobj": f1p["dobj"], }
-      templ := fmt.Sprintf("{subj} {verb} {dobj} %s.", bod.WornSlotName(slot))
+      var templ string
+      slotName := bod.WornSlotName(slot)
+      if slotName == "" {
+        templ = "{subj} {verb} {dobj}."
+      } else {
+        templ = fmt.Sprintf("{subj} {verb} {dobj} %s.", slotName)
+      }
       
       m := msg.New(gstring.Sprintm(templ, f3p))
       m.Add(pp, gstring.Sprintm(templ, f1p))

--- a/scripts/scripts.go
+++ b/scripts/scripts.go
@@ -25,16 +25,27 @@ var Scripts = make(map[string]Script)
 //
 // defined in pc/get.go
 //
-// "cannot_get_message_script"
+//   * "CGMS" ("Cannot Get Messsage Script")
+//     Provides custom messaging informing a player why a thing.Thing can't
+//     be picked up.
 //
 // defined in pc/lock.go
 //
-// "locked_script"
-// "lock_unlock_script"
+//   * "locked_script"
+//     Prevents a player from opening a thing.Openable and informs him that
+//     it's locked, unless the associated data value "locked_script_unlocked"
+//     is set to true.
+//
+//   * "lock_unlock_script"
+//     Designates a thing.Thing to be a "key" that allows a thing.Openable
+//     under the influence of the "locked_script" to be UNLOCKed by it.
 //
 // defined in pc/open.go
 //
-// "auto_close_script"
+//   * "auto_close_script"
+//     Causes a thing.Openable to shut automatically after it has been opened
+//    (after a specified delay).
+//
 
 var Bindings = make(map[string]map[string]string)
 

--- a/thing/thing.go
+++ b/thing/thing.go
@@ -15,7 +15,7 @@
 // may later get merged with ref.Interface), and has a pointer to where it
 // is (see LocVec, below).
 //
-// updated 2017-08-12
+// updated 2017-08-15
 //
 package thing
 
@@ -96,6 +96,10 @@ func sideStr(s byte) string {
   default:
     return ""
   }
+}
+
+func SideStr(s byte) string {
+  return sideStr(s)
 }
 
 func (v LocVec) String() string {


### PR DESCRIPTION
  * added EXAMINE verb
  * caused `thing.Container`s to leave behind things `BEHIND` and `UNDER` them when picked up
  * disallowed `put`ting things `BEHIND` or `UNDER` something being held
