### PR TITLE
changed game to listen on socket for commands

### DIFF
--- a/pc/parse.go
+++ b/pc/parse.go
@@ -192,12 +192,11 @@ func (pp *PlayerChar) Parse(cmd string) error {
   
   pp.Send(msg.Env{Type: "echo", Text: cmd})
   
-  if len(cmd) == 0 {
+  toks := strings.Fields(strings.ToLower(cmd))
+  if len(toks) == 0 {
     pp.QWrite("Sorry, what?")
     return nil
   }
-  
-  toks := strings.Fields(strings.ToLower(cmd))
   
   // process shortcuts
   if (cmd[0] == '"') || (cmd[0] == '\'') {


### PR DESCRIPTION
  * changed `dta5.go` to listen on a Unix socket named `ctrl` instead of on stdin; this allows the game to be run with `nohup`
  * fixed a bug wherein parsing commands would panic when sent commands of only whitespace